### PR TITLE
Add Django to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,9 @@ setup(
         'admin_comments',
     ],
     include_package_data=True,
-    install_requires=[],
+    install_requires=[
+        "django>=1.8",
+    ],
     license="MIT",
     zip_safe=False,
     keywords='django-admin-comments',


### PR DESCRIPTION
Django is the key dependency for this project; it should be
in the setup.py so that `pip install -e .` works.

(Note the tests don't depend on setup.py as tox config installs the required django version).

TODO: Bump required versions? 2.2 is the oldest officially-supported Django release. https://www.djangoproject.com/download/