### PR TITLE
Disable collapsible comments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,8 @@ Settings
 
        ADMIN_COMMENTS_FORMSET_CLASS = "myapp.forms.MyCustomCommentFormSet"
 
+- ``ADMIN_COMMENTS_COLLAPSIBLE_COMMENTS``: Should the comments be collapsible? (Default ``True``)
+
 Features
 --------
 

--- a/admin_comments/admin.py
+++ b/admin_comments/admin.py
@@ -10,8 +10,6 @@ class CommentInline(GenericTabularInline):
 
     readonly_fields = ('user',)
 
-    classes = ['collapse']
-
     def __init__(self, *args, **kwargs):
         form_klass = getattr(
             settings,
@@ -24,6 +22,11 @@ class CommentInline(GenericTabularInline):
             'admin_comments.forms.CommentInlineFormset')
 
         SHOW_EMPTY = getattr(settings, 'ADMIN_COMMENTS_SHOW_EMPTY', False)
+
+        COLLAPSIBLE_COMMENTS = getattr(settings, 'ADMIN_COMMENTS_COLLAPSIBLE_COMMENTS', True)
+
+        if COLLAPSIBLE_COMMENTS:
+            self.classes = ['collapse']
 
         CommentForm = get_class_from_str(form_klass)
         CommentFormSet = get_class_from_str(formset_klass)


### PR DESCRIPTION
For my use case, I don't want to expand comments every time I view a record. This adds the setting ADMIN_COMMENTS_COLLAPSIBLE_COMMENTS, which will only set ```classes = ['collapse']``` if True