### PR TITLE
Update Django to supported version 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,35 @@
 language: python
 
 python:
+  - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 
 before_install:
   # work around https://github.com/travis-ci/travis-ci/issues/8363
   - pyenv install 3.5.4
   - pyenv global system 3.5.4
 
+# You can generate this with `tox --listenvs`.
 env:
-  - TOX_ENV=py35-django-18
-  - TOX_ENV=py34-django-18
-  - TOX_ENV=py27-django-18
-  - TOX_ENV=py35-django-19
-  - TOX_ENV=py34-django-19
-  - TOX_ENV=py27-django-19
-  - TOX_ENV=py35-django-110
-  - TOX_ENV=py34-django-110
-  - TOX_ENV=py27-django-110
-  - TOX_ENV=py36-django-111
-  - TOX_ENV=py35-django-111
-  - TOX_ENV=py34-django-111
-  - TOX_ENV=py27-django-111
-  - TOX_ENV=py36-django-20
-  - TOX_ENV=py35-django-20
-  - TOX_ENV=py34-django-20
+  - TOX_ENV=py35-django-22
+  - TOX_ENV=py36-django-22
+  - TOX_ENV=py37-django-22
+  - TOX_ENV=py38-django-22
+  - TOX_ENV=py36-django-30
+  - TOX_ENV=py37-django-30
+  - TOX_ENV=py38-django-30
+  - TOX_ENV=py39-django-30
+  - TOX_ENV=py37-django-31
+  - TOX_ENV=py37-django-31
+  - TOX_ENV=py38-django-31
+  - TOX_ENV=py39-django-31
+  - TOX_ENV=py37-django-32
+  - TOX_ENV=py37-django-32
+  - TOX_ENV=py38-django-32
+  - TOX_ENV=py39-django-32
 
 matrix:
   fast_finish: true

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -24,33 +24,22 @@ INSTALLED_APPS = [
     "django.contrib.sites",
     "django.contrib.auth",
     "django.contrib.sessions",
+    'django.contrib.messages',
     "admin_comments",
     "example"
 ]
 
 SITE_ID = 1
 
-if django.VERSION >= (1, 10):
-    MIDDLEWARE = [
-        'django.middleware.security.SecurityMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    ]
-else:
-    MIDDLEWARE_CLASSES = [
-        'django.middleware.security.SecurityMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-        'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
-        'django.contrib.messages.middleware.MessageMiddleware',
-        'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    ]
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+]
 
 TEMPLATES = [
     {

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,19 @@
 [tox]
+# https://docs.djangoproject.com/en/3.2/faq/install/#what-python-version-can-i-use-with-django
 envlist =
-    {py27,py34,py35}-django-18
-    {py27,py34,py35}-django-19
-    {py27,py34,py35}-django-110
-    {py27,py34,py35,py36}-django-111
-    {py34,py35,py36}-django-20
+    {py35,py36,py37,py38}-django-22
+    {py36,py37,py38,py39}-django-30
+    {py37,py37,py38,py39}-django-31
+    {py37,py37,py38,py39}-django-32
 
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/admin_comments
 commands = coverage run --source admin_comments runtests.py
 deps =
-    django-18: Django>=1.8,<1.9
-    django-19: Django>=1.9,<1.10
-    django-110: Django>=1.10,<1.11
-    django-111: Django>=1.11,<2.0
-    django-20: Django>=2.0,<2.1
+    django-22: Django==2.2.*
+    django-30: Django==3.0.*
+    django-31: Django==3.1.*
+    django-32: Django==3.2.*
     -r{toxinidir}/requirements_test.txt
     -r{toxinidir}/requirements.txt
-basepython =
-    py36: python3.6
-    py35: python3.5
-    py34: python3.4
-    py27: python2.7


### PR DESCRIPTION
Update the minimum supported version for Django to 2.2, which is
the oldest supported version.

Also adds tox tests for the newer versions (up to 3.2).

This also includes updating the python versions to >=3.5, and
dropping support for Python 2.